### PR TITLE
Next scm config

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -1,1 +1,1 @@
-npm install -g jake jshint@0.5.0 csslint uglify-js && npm install jasmine-node && npm install express && npm install && if NOT [%1]==[-p] git submodule update --init
+npm install -g jake jshint@0.5.0 csslint uglify-js && npm install jasmine-node && npm install express && npm install && if NOT [%1]==[-scm] git submodule update --init

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
                                 </goals>
                                 <configuration>
                                     <executable>configure.bat</executable>
+                                    <arguments>
+                                        <argument>${scm}</argument>
+                                    </arguments>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Changed the configure script in order to allow for builds without git submodules being invoked in the configure script.

The following changes were made:
1. Added the flag in the configure script for scm builds.
2. Changed the maven script to add argument for scm build to the invocation of the configure script.
