### PR TITLE
Fixes lint error

### DIFF
--- a/test/functional/automatic/crossOrigin.js
+++ b/test/functional/automatic/crossOrigin.js
@@ -141,10 +141,6 @@ describe("White listing", function () {
         return script;
     }
 
-    function testLocalAccessFails(domain, path, messageToSend) {
-        testLocalAccess(domain, path, true, messageToSend);
-    }
-
     function testLocalAccess(domain, path, shouldFail, message) {
         var origin = 'http://' + domain,
             url = origin + (path || '/a/localTest.html'),
@@ -181,6 +177,10 @@ describe("White listing", function () {
         });
 
         return iframe;
+    }
+
+    function testLocalAccessFails(domain, path, messageToSend) {
+        testLocalAccess(domain, path, true, messageToSend);
     }
 
     function testExternalWebApi(domain, path, shouldFail, message) {


### PR DESCRIPTION
Fixes lint error in crossOrigin automated tests caused by
misordering of functions.

```
Reviewed By: Eric Pearson <epearson@rim.com>
Tested By: Nukul Bhasin <nbhasin@rim.com>
```
