### PR TITLE
Sensors support for simulator

### DIFF
--- a/ext/sensors/native/common.mk
+++ b/ext/sensors/native/common.mk
@@ -20,6 +20,4 @@ endif
 
 include $(MKFILES_ROOT)/qtargets.mk
 
-ifeq ($(CPU),arm)
 LIBS+=sensor
-endif

--- a/ext/sensors/native/sensors_js.cpp
+++ b/ext/sensors/native/sensors_js.cpp
@@ -17,23 +17,17 @@
 #include <json/reader.h>
 #include <string>
 #include "sensors_js.hpp"
-#ifndef __X86__
 #include "sensors_ndk.hpp"
-#endif
 
 Sensors::Sensors(const std::string& id) : m_id(id)
 {
-#ifndef __X86__
     m_pSensorsController = new webworks::SensorsNDK(this);
-#endif
 }
 
 Sensors::~Sensors()
 {
-#ifndef __X86__
     if (m_pSensorsController)
         delete m_pSensorsController;
-#endif
 }
 
 char* onGetObjList()
@@ -53,7 +47,6 @@ JSExt* onCreateObject(const std::string& className, const std::string& id)
 
 std::string Sensors::InvokeMethod(const std::string& command)
 {
-#ifndef __X86__
     int index = command.find_first_of(" ");
     std::string strCommand = command.substr(0, index);
     std::string arg = command.substr(index + 1, command.length());
@@ -74,12 +67,8 @@ std::string Sensors::InvokeMethod(const std::string& command)
     } else if (strCommand == "supportedSensors") {
         return m_pSensorsController->SupportedSensors();
     }
-#endif
-#ifndef __X86__
+
     return "";
-#else
-    return command;
-#endif
 }
 
 bool Sensors::CanDelete()

--- a/ext/sensors/native/sensors_ndk.cpp
+++ b/ext/sensors/native/sensors_ndk.cpp
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#ifndef __X86__
 #define SENSOR_MSG_PULSE 64
 #define SENSOR_BASE_PULSE 128
 
@@ -344,4 +343,4 @@ void SensorsNDK::createSensorMap()
     _sensorTypeMap["deviceholster"] = std::make_pair(SENSOR_TYPE_HOLSTER, config);
 }
 }
-#endif
+


### PR DESCRIPTION
This change reverts disabling sensors on the simulator, as of the last NDK it is now supported

Fixes #359
