### PR TITLE
Adding override API + manual tests to ui.contextmenu namespace. Provides

### DIFF
--- a/ext/ui.contextmenu/client.js
+++ b/ext/ui.contextmenu/client.js
@@ -28,7 +28,9 @@ function defineReadOnlyActions(name, value) {
 
 function listen() {
     window.blackberry.event.addEventListener('contextmenu.executeMenuAction', function (actionId) {
-        _storedCallbacks[actionId]();
+        if (typeof _storedCallbacks[actionId] === 'function') {
+            _storedCallbacks[actionId]();
+        }
     });
 }
 
@@ -52,6 +54,34 @@ Object.defineProperty(contextmenu, "enabled", {
         }
     }
 });
+
+contextmenu.clearOverride = function (actionId) {
+
+    if (typeof actionId === 'undefined') {
+        return 'Clearing override on a menu item requires an actionId';
+    }
+
+    if (_storedCallbacks[actionId]) {
+        delete _storedCallbacks[actionId];
+    }
+
+    window.webworks.execSync(_ID, 'clearOverride', { actionId: actionId});
+};
+
+contextmenu.overrideItem = function (action, callback) {
+
+    if (typeof action.actionId === 'undefined') {
+        return 'Overriding a menu item requires an actionId';
+    }
+
+    _storedCallbacks[action.actionId] = callback;
+    if (!_listeningForCallbacks) {
+        _listeningForCallbacks = true;
+        listen();
+    }
+    window.webworks.execSync(_ID, 'overrideItem', {action: action});
+};
+
 
 contextmenu.addItem = function (contexts, action, callback) {
 
@@ -103,7 +133,6 @@ defineReadOnlyActions("COPY", "Copy");
 defineReadOnlyActions("PASTE", "Paste");
 defineReadOnlyActions("SELECT", "Select");
 defineReadOnlyActions("COPY_LINK", "CopyLink");
-defineReadOnlyActions("OPEN_LINK", "OpenLink");
 defineReadOnlyActions("SAVE_LINK_AS", "SaveLinkAs");
 defineReadOnlyActions("SAVE_IMAGE", "SaveImage");
 defineReadOnlyActions("COPY_IMAGE_LINK", "CopyImageLink");

--- a/ext/ui.contextmenu/index.js
+++ b/ext/ui.contextmenu/index.js
@@ -32,6 +32,26 @@ function enabled(success, fail, args, env) {
         success(_overlayWebView.contextMenu.enabled);
     }
 }
+/*
+ * Returns true if it was able to override the item, false if there
+ * was an error doing so.
+ */
+function overrideItem(success, fail, args, env) {
+    args.action = JSON.parse(decodeURIComponent(args.action));
+    args.handler = function (actionId) {
+        _event.trigger("contextmenu.executeMenuAction", actionId);
+    };
+    success(_overlayWebView.contextMenu.overrideItem(args.action, args.handler));
+}
+
+/*
+ * Returns true if the item could be cleared successfully and
+ * false otherwise.
+ */
+function clearOverride(success, fail, args, env) {
+    var actionId = JSON.parse(decodeURIComponent(args.actionId));
+    success(_overlayWebView.contextMenu.clearOverride(actionId));
+}
 
 function addItem(success, fail, args, env) {
     args.contexts = JSON.parse(decodeURIComponent(args.contexts));
@@ -58,6 +78,8 @@ contextmenu = {
     enabled: enabled,
     addItem: addItem,
     removeItem: removeItem,
+    overrideItem: overrideItem,
+    clearOverride: clearOverride,
     defineCustomContext: defineCustomContext
 };
 

--- a/test/test-app/manual/ContextMenu/index.htm
+++ b/test/test-app/manual/ContextMenu/index.htm
@@ -53,47 +53,47 @@
         <br />
         <br />
 
+        <h4>Telephone</h4>
+        <a href="tel:654-2343-23423">A phone number link for context tests</a>
+        <br />
+        <br />
         <div align="left">
-            <br />
             <br />
             <button onclick="overridePlatform()">Add a custom Item that overrides the "Copy action"</button>
             <br />
+            <button onclick="overrideMenuServiceShare()">Experimental MenuService override, technically not supported, but provided for completness</button>
             <br />
-            <button onclick="overrideMenuService()">Add a custom Item that overrides a "Menu Service" action</button>
+            <button onclick="clearCopyOverride()">Clear the Copy action</button>
             <br />
-            <br />
-            <br />
+            <button onclick="clearMSOverride()">Clear the Menu Service override</button>
             <br />
             <button onclick="blackberry.ui.contextmenu.enabled = true">Enable Context Menu</button>
             <br />
-            <br />
             <button onclick="blackberry.ui.contextmenu.enabled = false">Disable Context Menu</button>
             <br />
-            <br />
             <button onclick="addMenuItemContextAll()">Add custom item [CONTEXT_ALL]</button>
+            <br />
             <button onclick="removeMenuItemContextAll()">Remove custom item [CONTEXT_ALL]</button>
             <br />
-            <br />
             <button onclick="addMenuItemContextLink()">Add custom item [CONTEXT_LINK]</button>
+            <br />
             <button onclick="removeMenuItemContextLink()">Remove custom item [CONTEXT_LINK]</button>
             <br />
-            <br />
             <button onclick="addMenuItemContextInput()">Add custom item [CONTEXT_INPUT]</button>
+            <br />
             <button onclick="removeMenuItemContextInput()">Remove custom item [CONTEXT_INPUT]</button>
             <br />
-            <br />
             <button onclick="addMenuItemContextIText()">Add custom item [CONTEXT_TEXT]</button>
+            <br />
             <button onclick="removeMenuItemContextIText()">Remove custom item [CONTEXT_TEXT]</button>
             <br />
-            <br />
             <button onclick="addMenuItemContextImage()">Add custom item [CONTEXT_IMAGE]</button>
+            <br />
             <button onclick="removeMenuItemContextImage()">Remove custom item [CONTEXT_IMAGE]</button>
             <br />
-            <br />
             <button onclick="addMenuItemContextImageLink()">Add custom item [CONTEXT_IMAGE_LINK]</button>
+            <br />
             <button onclick="removeMenuItemContextImageLink()">Remove custom item [CONTEXT_IMAGE_LINK]</button>
-            <br />
-            <br />
         </div>
         <br />
         <br />

--- a/test/test-app/manual/ContextMenu/script.js
+++ b/test/test-app/manual/ContextMenu/script.js
@@ -19,21 +19,25 @@ var callback = function() {
 };
 
 function overridePlatform() {
-    var myItem = {actionId: blackberry.ui.contextmenu.ACTION_COPY, label: 'CustomCopy!', icon:'local:///manual/ContextMenu/icon.png'},
-        contexts = [blackberry.ui.contextmenu.CONTEXT_ALL];
-
-    blackberry.ui.contextmenu.addItem(contexts, myItem, function() {
+    var myItem = {actionId: blackberry.ui.contextmenu.ACTION_COPY, label: 'CustomCopy!', icon:'local:///manual/ContextMenu/icon.png'};
+    blackberry.ui.contextmenu.overrideItem(myItem, function() {
         alert("Wow you succesfully overrode the platform menu item Copy");
     });
 }
 
-function overrideMenuService() {
-    var myItem = {actionId: 'MenuService-Share', label: 'CustomShare', icon:'local:///manual/ContextMenu/icon.png'},
-        contexts = [blackberry.ui.contextmenu.CONTEXT_ALL];
-
-    blackberry.ui.contextmenu.addItem(contexts, myItem, function() {
+function overrideMenuServiceShare() {
+    var myItem = {actionId: 'MenuService-1', label: 'CustomShare', icon:'local:///manual/ContextMenu/icon.png'};
+    blackberry.ui.contextmenu.overrideItem(myItem, function() {
         alert("Wow you succesfully overrode the menu service action");
     });
+}
+
+function clearCopyOverride() {
+    blackberry.ui.contextmenu.clearOverride(blackberry.ui.contextmenu.ACTION_COPY);
+}
+
+function clearMSOverride() {
+    blackberry.ui.contextmenu.clearOverride('MenuService-1');
 }
 
 function addMenuItemContextAll() {

--- a/test/unit/ext/ui.contextmenu/client.js
+++ b/test/unit/ext/ui.contextmenu/client.js
@@ -24,13 +24,19 @@ var _ID = "blackberry.ui.contextmenu",
         execAsync: jasmine.createSpy("execAsync").andCallFake(function (service, action, args) {
             return true;
         })
+    },
+    mockedEvent = {
+        addEventListener : jasmine.createSpy()
     };
 
 describe("blackberry.ui.contextmenu client", function () {
 
     beforeEach(function () {
         GLOBAL.window = {
-            webworks: mockedWebworks
+            webworks: mockedWebworks,
+            blackberry : {
+                event : mockedEvent
+            },
         };
         client = require(_apiDir + "/client");
     });
@@ -106,4 +112,17 @@ describe("blackberry.ui.contextmenu client", function () {
         expect(mockedWebworks.execAsync).toHaveBeenCalledWith(_ID, "defineCustomContext", {context: "myContext", options: options});
     });
 
+    it("Can override an item with an action and handler", function () {
+        var myItem = {actionId: 'OpenLink', label: 'This is a lable'},
+            handler = jasmine.createSpy();
+        client.overrideItem(myItem, handler);
+        expect(mockedEvent.addEventListener).toHaveBeenCalledWith('contextmenu.executeMenuAction', jasmine.any(Function));
+        expect(mockedWebworks.execSync).toHaveBeenCalledWith(_ID, 'overrideItem', {action: myItem});
+    });
+
+    it("Can clear an item with an actionId", function () {
+        var actionId = 'OpenLink';
+        client.clearOverride(actionId);
+        expect(mockedWebworks.execSync).toHaveBeenCalledWith(_ID, 'clearOverride', {actionId: actionId});
+    });
 });

--- a/test/unit/ext/ui.contextmenu/index.js
+++ b/test/unit/ext/ui.contextmenu/index.js
@@ -22,6 +22,8 @@ var _extDir = __dirname + "./../../../../ext/",
     mockedContextMenu = {
         addItem: jasmine.createSpy(),
         removeItem: jasmine.createSpy(),
+        overrideItem: jasmine.createSpy(),
+        clearOverride: jasmine.createSpy(),
         defineCustomContext: jasmine.createSpy(),
         enabled : true
     },
@@ -147,6 +149,50 @@ describe("blackberry.ui.contextmenu index", function () {
             includePlatformItems: false,
             includeMenuServiceItems: false
         });
+    });
+
+    it("has an override menu item function", function () {
+        expect(contextmenu.overrideItem).toBeDefined();
+    });
+
+    it("has an clearmenu item function", function () {
+        expect(contextmenu.clearOverride).toBeDefined();
+    });
+
+    it("can override a platform menu item", function () {
+        var args = {
+                action: encodeURIComponent(JSON.stringify({actionId: 'Paste'}))
+            },
+            env = {};
+        contextmenu.overrideItem(success, fail, args, env);
+        expect(mockedContextMenu.overrideItem).toHaveBeenCalledWith({ actionId: 'Paste'}, jasmine.any(Function));
+    });
+
+    it("can override a platform MenuService menu item", function () {
+        var args = {
+                action: encodeURIComponent(JSON.stringify({actionId: 'MenuService-Share'}))
+            },
+            env = {};
+        contextmenu.overrideItem(success, fail, args, env);
+        expect(mockedContextMenu.overrideItem).toHaveBeenCalledWith({ actionId: 'MenuService-Share'}, jasmine.any(Function));
+    });
+
+    it("can clear an overriden platform menu item", function () {
+        var args = {
+                actionId: encodeURIComponent(JSON.stringify('Copy'))
+            },
+            env = {};
+        contextmenu.clearOverride(success, fail, args, env);
+        expect(mockedContextMenu.clearOverride).toHaveBeenCalledWith('Copy');
+    });
+
+    it("can clear an overriden menu item", function () {
+        var args = {
+                actionId: encodeURIComponent(JSON.stringify('MenuService-Share'))
+            },
+            env = {};
+        contextmenu.clearOverride(success, fail, args, env);
+        expect(mockedContextMenu.clearOverride).toHaveBeenCalledWith('MenuService-Share');
     });
 
 });


### PR DESCRIPTION
developers the ability to override parts of default system actions if
they wish to implement their own share/Copy etc.

Additiional Capabilities on to Issue: blackberry/BB10-WebWorks-Framework#184
