### PR TITLE
Modifies the WebWorks framework so that the content url no longer needs to be whitelisted

### DIFF
--- a/lib/policy/webkitOriginAccess.js
+++ b/lib/policy/webkitOriginAccess.js
@@ -1,0 +1,125 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var config = require('./../config'),
+    utils = require('./../utils'),
+    Whitelist = require('./whitelist').Whitelist,
+    LOCAL_URI = "local://",
+    FILE_URI = "file://",
+    WW_URI = utils.getURIPrefix(),
+    _domains = [
+        {
+            url: LOCAL_URI,
+            allowSubDomains: true
+        }
+    ],
+    _webviews = [],
+    _isInitialized = false,
+    _whitelist = new Whitelist();
+
+function addOriginAccessWhitelistEntry(webview, source, destination, allowSubDomains) {
+    webview.addOriginAccessWhitelistEntry(source, destination, !!allowSubDomains);
+}
+
+function addDomain(url, allowSubDomains) {
+    var parsedUri = utils.parseUri(url);
+
+    allowSubDomains = !!allowSubDomains;
+
+    if (utils.isLocalURI(parsedUri)) {
+        url = LOCAL_URI;
+    } else if (utils.isFileURI(parsedUri)) {
+        url = FILE_URI;
+    } else {
+        url = parsedUri.scheme + "://" + parsedUri.authority;
+    }
+
+    if (_whitelist.isAccessAllowed(url) && !_domains.some(function (domain) {
+        return domain.url === url;
+    })) {
+        _webviews.forEach(function (webview) {
+            addOriginAccessWhitelistEntry(webview, url, WW_URI, true);
+
+            _domains.forEach(function (domain) {
+                addOriginAccessWhitelistEntry(webview, domain.url, url, allowSubDomains);
+                addOriginAccessWhitelistEntry(webview, url, domain.url, domain.allowSubDomains);
+            });
+
+        });
+
+        _domains.push({
+            url: url,
+            allowSubDomains: allowSubDomains
+        });
+    }
+}
+
+function initializeDomains() {
+    var accessElements = config.accessList;
+
+    accessElements.forEach(function (element, index, array) {
+        var uri = (element.uri === 'WIDGET_LOCAL' ? LOCAL_URI : element.uri);
+        addDomain(uri, !!element.allowSubDomain);
+    });
+
+    addDomain(config.content, true);
+}
+
+function initializaWebview(webview) {
+    //Always allow file access from local and let the OS deal with permissions
+    addOriginAccessWhitelistEntry(webview, LOCAL_URI, FILE_URI, true);
+    addOriginAccessWhitelistEntry(webview, FILE_URI, LOCAL_URI, true);
+    //Always allow LOCAL access to URIs
+    addOriginAccessWhitelistEntry(webview, LOCAL_URI, WW_URI, true);
+
+    _domains.forEach(function (domain, domainIndex, domainArray) {
+        var i,
+            nextDomain;
+
+        if (domain.uri !== LOCAL_URI) {
+            addOriginAccessWhitelistEntry(webview, domain.url, WW_URI, true);
+        }
+
+        for (i = domainIndex + 1; i < domainArray.length; i++) {
+            nextDomain = domainArray[i];
+            addOriginAccessWhitelistEntry(webview, domain.url, nextDomain.url, nextDomain.allowSubDomains);
+            addOriginAccessWhitelistEntry(webview, nextDomain.url, domain.url, domain.allowSubDomains);
+        }
+    });
+
+}
+
+module.exports = {
+
+    addWebView: function (webview) {
+        if (_webviews.indexOf(webview) === -1) {
+            _webviews.push(webview);
+            initializaWebview(webview);
+            if (!_isInitialized) {
+                initializeDomains();
+                _isInitialized = true;
+            }
+        }
+    },
+
+    addOriginAccess: function (origin, allowSubDomains) {
+        if (!_isInitialized) {
+            initializeDomains();
+            _isInitialized = true;
+        }
+        addDomain(origin, allowSubDomains);
+    }
+};

--- a/lib/webview.js
+++ b/lib/webview.js
@@ -18,40 +18,13 @@ var request = require('./request'),
     utils = require('./utils'),
     config = require('./config'),
     permissions = require('./permissions'),
+    webkitOriginAccess = require("./policy/webkitOriginAccess"),
     CHROME_HEIGHT = 0,
     OUT_OF_PROCESS = 1,
     LOCAL_URI = "local://",
     FILE_URI = "file://",
     webview,
     _webviewObj;
-
-function enableWhitelisting(id) {
-    var accessElements = config.accessList;
-    accessElements.forEach(function (element, index, array) {
-        var uri = (element.uri === 'WIDGET_LOCAL' ? LOCAL_URI : element.uri),
-            parsedUri = utils.parseUri(uri);
-
-        if (utils.isFileURI(parsedUri)) {
-            uri = FILE_URI;
-        }
-
-        if (element.features && element.features.length) {
-            //Allow access from a whitelisted domain to local
-            _webviewObj.addOriginAccessWhitelistEntry(LOCAL_URI, uri, true);
-            _webviewObj.addOriginAccessWhitelistEntry(uri, LOCAL_URI,  element.allowSubDomain);
-            //Allow access from a whitelisted domain to content start page
-            _webviewObj.addOriginAccessWhitelistEntry(config.content, uri, true);
-            _webviewObj.addOriginAccessWhitelistEntry(uri, config.content,  element.allowSubDomain);
-            //Allow access from a whitelisted domain to APIs
-            _webviewObj.addOriginAccessWhitelistEntry(uri, utils.getURIPrefix(), true);
-        }
-    });
-    //Always allow file access from local and let the OS deal with permissions
-    _webviewObj.addOriginAccessWhitelistEntry(LOCAL_URI, FILE_URI, true);
-    _webviewObj.addOriginAccessWhitelistEntry(FILE_URI, LOCAL_URI, true);
-    //Always allow the content page to access URIs
-    _webviewObj.addOriginAccessWhitelistEntry(config.content, utils.getURIPrefix(), true);
-}
 
 webview =
     {
@@ -66,7 +39,9 @@ webview =
             _webviewObj.visible = true;
             _webviewObj.active = true;
             _webviewObj.zOrder = 0;
-            enableWhitelisting(_webviewObj.id);
+
+            webkitOriginAccess.addWebView(_webviewObj);
+
             _webviewObj.setGeometry(0, CHROME_HEIGHT, screen.width, screen.height - CHROME_HEIGHT);
 
             if (typeof config.backgroundColor !== 'undefined') {

--- a/test/unit/lib/policy/webkitOriginAccess.js
+++ b/test/unit/lib/policy/webkitOriginAccess.js
@@ -1,0 +1,213 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var LIB_PATH = __dirname + "/../../../../lib/",
+    utils = require(LIB_PATH + 'utils'),
+    webkitOriginAccess = require(LIB_PATH + "policy/webkitOriginAccess"),
+    LOCAL_URI = "local://",
+    FILE_URI = "file://",
+    WW_URI = utils.getURIPrefix(),
+    mockWebView;
+
+describe("lib/policy/webkitOriginAccess", function () {
+    beforeEach(function () {
+        mockWebView = {
+            addOriginAccessWhitelistEntry: jasmine.createSpy()
+        };
+    });
+
+    afterEach(function () {
+        mockWebView = undefined;
+        delete require.cache[require.resolve(LIB_PATH + "config")];
+        delete require.cache[require.resolve(LIB_PATH + "policy/webkitOriginAccess")];
+        webkitOriginAccess = require(LIB_PATH + "policy/webkitOriginAccess");
+    });
+
+    function mockConfig(options) {
+        delete require.cache[require.resolve(LIB_PATH + "config")];
+        delete require.cache[require.resolve(LIB_PATH + "policy/webkitOriginAccess")];
+
+        var config = require(LIB_PATH + "config");
+
+        if (options.accessList) {
+            config.accessList = options.accessList;
+        }
+        if (options.hasMultiAccess) {
+            config.hasMultiAccess = !! options.hasMultiAccess;
+        }
+        if (options.content) {
+            config.content = options.content;
+        }
+
+        webkitOriginAccess = require(LIB_PATH + "policy/webkitOriginAccess");
+    }
+
+    describe("addWebview function", function () {
+
+        it("exists", function () {
+            expect(webkitOriginAccess.addWebView).toBeDefined();
+        });
+
+        it("sets up one time whitelisting", function () {
+            webkitOriginAccess.addWebView(mockWebView);
+
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, FILE_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(FILE_URI, LOCAL_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, WW_URI, true);
+        });
+
+        it("initializes the webview with whitelisting based on the config", function () {
+            var mockAccessList = [
+                    {
+                        uri : "http://google.com",
+                        allowSubDomain : true,
+                        features : null
+                    }
+                ],
+                mockContent = "http://remoteStartPage.org";
+
+            mockConfig({accessList: mockAccessList, content: mockContent});
+
+            webkitOriginAccess.addWebView(mockWebView);
+
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, mockAccessList[0].uri, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(mockAccessList[0].uri, LOCAL_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(mockAccessList[0].uri, WW_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, mockContent, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(mockContent, LOCAL_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(mockContent, WW_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(mockContent, mockAccessList[0].uri, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(mockAccessList[0].uri, mockContent, true);
+        });
+
+        it("initializes the webview with whitelisting based on what domains have been added", function () {
+            var mockAccessList = [{
+                    uri : "http://google.com",
+                    allowSubDomain : true,
+                    features : null
+                }],
+                url = "http://www.rim.com";
+
+            mockConfig({accessList: mockAccessList, hasMultiAccess: true});
+
+            webkitOriginAccess.addOriginAccess(url, true);
+
+            webkitOriginAccess.addWebView(mockWebView);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, url, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, LOCAL_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, "http://google.com", true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith("http://google.com", url, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, WW_URI, true);
+        });
+
+        it("will not initialize twice", function () {
+            var origCallCount;
+
+            webkitOriginAccess.addWebView(mockWebView);
+            origCallCount = mockWebView.addOriginAccessWhitelistEntry.callCount;
+            webkitOriginAccess.addWebView(mockWebView);
+
+            expect(mockWebView.addOriginAccessWhitelistEntry.callCount).toEqual(origCallCount);
+        });
+
+    });
+
+    describe("addOriginAccess function", function () {
+        it("exists", function () {
+            expect(webkitOriginAccess.addOriginAccess).toBeDefined();
+        });
+
+        it("Treats falsey values as false", function () {
+            var url = "http://www.rim.com";
+
+            webkitOriginAccess.addWebView(mockWebView);
+            webkitOriginAccess.addOriginAccess(url);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, url, false);
+        });
+
+        it("Parses url and only uses authority", function () {
+            var url = "http://www.rim.com/grrr/arrg/blah.htm",
+                authority = "http://www.rim.com";
+
+            webkitOriginAccess.addWebView(mockWebView);
+            webkitOriginAccess.addOriginAccess(url);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, authority, false);
+        });
+
+        //Because local:// is already a domain, the spy should not have no new calls
+        it("Local uris are treated as local://", function () {
+            var url = "local:///buy/local/beef/mmmmmmmmmmmmm/Steak.yum",
+                origCallCount;
+
+            webkitOriginAccess.addWebView(mockWebView);
+            webkitOriginAccess.addOriginAccess(url);
+            origCallCount = mockWebView.addOriginAccessWhitelistEntry.callCount;
+            webkitOriginAccess.addOriginAccess(url);
+            expect(mockWebView.addOriginAccessWhitelistEntry.callCount).toEqual(origCallCount);
+        });
+
+        it("File uris are treated as file://", function () {
+            var url = "file:///buy/local/beef/mmmmmmmmmmmmm/Steak.yum",
+                authority = "file://";
+
+            webkitOriginAccess.addWebView(mockWebView);
+            webkitOriginAccess.addOriginAccess(url);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, authority, false);
+        });
+
+        it("updates all managed webviews of the new domain access", function () {
+            var mockWebView2 = {
+                    addOriginAccessWhitelistEntry: jasmine.createSpy()
+                },
+                url = "http://www.rim.com";
+
+            webkitOriginAccess.addWebView(mockWebView);
+            webkitOriginAccess.addWebView(mockWebView2);
+
+            webkitOriginAccess.addOriginAccess(url, true);
+
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, url, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, LOCAL_URI, true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, WW_URI, true);
+            expect(mockWebView2.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(LOCAL_URI, url, true);
+            expect(mockWebView2.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, LOCAL_URI, true);
+            expect(mockWebView2.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, WW_URI, true);
+        });
+
+        it("updates all managed webviews when a new domain is added", function () {
+            var mockAccessList = [{
+                    uri : "http://google.com",
+                    allowSubDomain : true,
+                    features : null
+                }],
+                url = "http://www.rim.com";
+
+            mockConfig({accessList: mockAccessList, hasMultiAccess: true});
+
+            webkitOriginAccess.addWebView(mockWebView);
+
+            expect(mockWebView.addOriginAccessWhitelistEntry).not.toHaveBeenCalledWith(url, "http://google.com", true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).not.toHaveBeenCalledWith("http://google.com", url, true);
+
+            webkitOriginAccess.addOriginAccess(url, true);
+
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith(url, "http://google.com", true);
+            expect(mockWebView.addOriginAccessWhitelistEntry).toHaveBeenCalledWith("http://google.com", url, true);
+        });
+
+    });
+
+});


### PR DESCRIPTION
```
Fixes blackberry/BB10-WebWorks-Framework#413

Modifies the whitelisting implementation to more broadly add
origin access into webkit and allow for future expansion.
As part of this it will always add an entry for the config.content
entry.

Reviewed By: Nukul Bhasin <nbhasin@rim.com>
Tested By: Tracy Li <tli@rim.com>
```
