### PR TITLE
Modifies the Notification extension to remove the string prepended to

### DIFF
--- a/ext/notification/client.js
+++ b/ext/notification/client.js
@@ -53,7 +53,7 @@ Notification = function (title, options) {
 
     // itemId is required parameter that identifies the notification. If tag is provided it serves as an itemId, when tag isn't provided itemId is generated.
     if (!options.tag) {
-        options.tag = "itemId" + generateItemId();
+        options.tag = generateItemId() + "_itemId";
     }
 
     if (options.onerror || options.onshow) {

--- a/ext/notification/index.js
+++ b/ext/notification/index.js
@@ -53,11 +53,12 @@ module.exports = {
         }
 
         // Calling delete with tag before writing new notification, ensures new notification will override the old one.
-        _notification.remove(args.options);
+        _notification.remove(args.options.tag);
         _notification.notify(args, getCallback(args.options.eventName));
 
         success();
     },
+
     remove: function (success, fail, args) {
         var key;
 
@@ -70,5 +71,5 @@ module.exports = {
         _notification.remove(args.tag);
 
         success();
-    },
+    }
 };

--- a/test/unit/ext/notification/index.js
+++ b/test/unit/ext/notification/index.js
@@ -73,7 +73,7 @@ describe("notification index", function () {
 
         describe("notify method", function () {
             afterEach(function () {
-                expect(mockNotification.remove).toHaveBeenCalledWith(args.options);
+                expect(mockNotification.remove).toHaveBeenCalledWith(args.options.tag);
                 delete require.cache[require.resolve(_libDir + "config")];
             });
 


### PR DESCRIPTION
the itemid

```
Reviewed By: Nukul Bhasin <nbhasin@rim.com>
Tested By: Igor Shneur <ishneur@rim.com>
```
