### PR TITLE
Remove automated test for query in blackberry.invoke

### DIFF
--- a/test/functional/automatic/blackberry.invoke.js
+++ b/test/functional/automatic/blackberry.invoke.js
@@ -18,59 +18,6 @@ describe("blackberry.invoke", function () {
         expect(blackberry.invoke).toBeDefined();
     });
 
-    it('query should be able to perform a query on the device', function () {
-        var delay = 750,
-            home = blackberry.io.home,
-            iconPath = home.substring(0, home.lastIndexOf("data")) + "public/native/default-icon.png",
-            query = {
-                "action": "bb.action.WWTEST",
-                "uri": "file://",
-                "type": "text/plain",
-                "target_type": ["APPLICATION"],
-                "action_type": "ALL"
-            },
-            onSuccess = jasmine.createSpy("query onSuccess").andCallFake(function (responseArray) {
-
-                expect(responseArray).toBeDefined();
-                responseArray.forEach(function (response) {
-                    expect(response.action).toBeDefined();
-                    expect(response.action).toEqual("bb.action.WWTEST");
-                    expect(response.icon).toBeDefined();
-                    expect(response.label).toBeDefined();
-                    expect(response["default"]).toBeDefined();
-                    expect(response["default"]).toEqual("com.webworks.test.functional.query.target");
-                    expect(response.targets).toBeDefined();
-                    expect(response.targets[0]).toBeDefined();
-                    response.targets.forEach(function (target) {
-                        expect(target.key).toBeDefined();
-                        expect(target.key).toEqual("com.webworks.test.functional.query.target");
-                        expect(target.icon).toBeDefined();
-                        expect(target.icon).not.toEqual(iconPath);
-                        expect(target.label).toBeDefined();
-                        expect(target.label).toEqual("WebWorks Test App-en");//Localized application name [en]
-                        expect(target.type).toBeDefined();
-                        expect(target.type).toEqual("APPLICATION");
-                        expect(target.perimeter).toBeDefined();
-                        expect(target.perimeter).toEqual("personal");
-                    });
-                });
-            }),
-            onError = jasmine.createSpy("query onError");
-
-        runs(function () {
-            blackberry.invoke.query(query, onSuccess, onError);
-        });
-
-        waitsFor(function () {
-            return onSuccess.callCount > 0 || onError.callCount > 0;
-        }, "The callback flag should be set to true", delay);
-
-        runs(function () {
-            expect(onSuccess).toHaveBeenCalled();
-            expect(onError).not.toHaveBeenCalled();
-        });
-    });
-
     it('blackberry.invoke.file_transfer_mode constants should be defined', function () {
         expect(blackberry.invoke.FILE_TRANSFER_PRESERVE).toBe('PRESERVE');
         expect(blackberry.invoke.FILE_TRANSFER_COPY_RO).toBe('COPY_RO');


### PR DESCRIPTION
This seems to be interfering with the invoke framework at times, causing all invoke tests to fail. When it does pass, it is only because an empty array is returned. Removing the test for now while the issue is being investigated.

Issue #451
