### PR TITLE
updated blackberry.app to not clobber navigator

### DIFF
--- a/test/functional/automatic/blackberry.app.js
+++ b/test/functional/automatic/blackberry.app.js
@@ -105,10 +105,10 @@ describe("blackberry.app", function () {
     });
 
     describe("internationalization support", function () {
-        var originalLanguage = navigator.language;
+        var originalNavigator = window.navigator;
 
         afterEach(function () {
-            window.navigator = { language : originalLanguage };
+            window.navigator = originalNavigator;
         });
 
         it('blackberry.app.name - default value should exist', function () {


### PR DESCRIPTION
The localization tests for blackberry.app were overriding
window.navigator. Updated so that navigator is restored
after tests are done running.

Tested in Ripple and on Device with build 1637
