### PR TITLE
fixes path for back button in manual test page

### DIFF
--- a/test/test-app/manual/index.htm
+++ b/test/test-app/manual/index.htm
@@ -3,7 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 <body>
-    <button onclick="document.location.href='local:///index.htm'">Back</button><br />
+    <button onclick="document.location.href='local:///index.html'">Back</button><br />
     <h2>Manual Tests</h2>
     <a href="local:///manual/framework/SpecRunner.htm">Framework</a><br />
     <a href="local:///manual/framework-split/main.htm">Framework SPLIT</a><br />


### PR DESCRIPTION
Currently the back button from the manual test page does not work, forcing the user to kill the app to get back to the main screen. 
