### PR TITLE
Fixes testApp to work in enterprise perimeter

### DIFF
--- a/test/functional/automatic/blackberry.io.js
+++ b/test/functional/automatic/blackberry.io.js
@@ -1,5 +1,5 @@
 describe("FileSystem API", function () {
-     
+
     it("Sandboxed FileSystem write file", function () {
         var errorHandler = jasmine.createSpy().andCallFake(function (e) {
                 console.log(e);
@@ -26,7 +26,7 @@ describe("FileSystem API", function () {
                 fs.root.getFile(fileName, {create: true}, gotFile, errorHandler);
             }
 
-            blackberry.io.sandbox = true;           
+            blackberry.io.sandbox = true;
             window.webkitRequestFileSystem(window.PERSISTENT, 1024 * 1024, onInitFs, errorHandler);
         });
 
@@ -50,7 +50,7 @@ describe("FileSystem API", function () {
             fileContent;
 
         runs(function () {
-            
+
             function gotFile(fileEntry) {
                 fileEntry.file(function (file) {
                     var reader = new FileReader();
@@ -83,13 +83,13 @@ describe("FileSystem API", function () {
             expect(fileContent).toBe("this is text data");
         });
     });
-    
+
     it("Unsandboxed FileSystem write file", function () {
         var errorHandler = jasmine.createSpy().andCallFake(function (e) {
                 console.log(e);
             }),
             fileWritten = false,
-            dir = "/accounts/1000/shared/documents/",
+            dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "textData.txt",
             bb = new window.WebKitBlobBuilder();
 
@@ -112,7 +112,7 @@ describe("FileSystem API", function () {
                 fs.root.getFile(dir + fileName, {create: true}, gotFile, errorHandler);
             }
 
-            
+
             window.webkitRequestFileSystem(window.PERSISTENT, 1024 * 1024, onInitFs, errorHandler);
         });
 
@@ -132,7 +132,7 @@ describe("FileSystem API", function () {
                 console.log(e);
             }),
             fileRead = false,
-            dir = "/accounts/1000/shared/documents/",
+            dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "textData.txt",
             fileContent;
 
@@ -170,4 +170,4 @@ describe("FileSystem API", function () {
             expect(fileContent).toBe("this is text data");
         });
     });
-});    
+});

--- a/test/functional/automatic/blackberry.pim.contacts.js
+++ b/test/functional/automatic/blackberry.pim.contacts.js
@@ -32,7 +32,7 @@ function deleteContactWithMatchingLastName(lastName) {
             filter: [{
                 fieldName: ContactFindOptions.SEARCH_FIELD_FAMILY_NAME,
                 fieldValue: lastName
-            }], 
+            }]
         },
         numContactsRemoved = 0,
         numContactsFound = 0,
@@ -50,7 +50,7 @@ function deleteContactWithMatchingLastName(lastName) {
         });
     }, function (error) {
         console.log("Failed to clean up contacts with last name '" + lastName + "', error code=" + error.code);
-    }); 
+    });
 
     waitsFor(function () {
         return numContactsRemoved === numContactsFound;
@@ -179,7 +179,7 @@ describe("blackberry.pim.contacts", function () {
             expect(ContactActivity.INCOMING).toBeDefined();
             expect(ContactActivity.OUTGOING).toBeDefined();
         });
-        
+
         it('blackberry.pim.contacts.ContactActivity constants should be read-only', function () {
             testReadOnly(ContactActivity, "INCOMING");
             testReadOnly(ContactActivity, "OUTGOING");
@@ -268,10 +268,10 @@ describe("blackberry.pim.contacts", function () {
 
         it('Can create blackberry.pim.contacts.ContactPhoto object', function () {
             var photo = {
-                originalFilePath: "/accounts/1000/shared/pictures/001.jpg", 
+                originalFilePath: blackberry.io.sharedFolder + "/pictures/001.jpg",
                 pref: true
             };
-            expect(photo.originalFilePath).toBe("/accounts/1000/shared/pictures/001.jpg");
+            expect(photo.originalFilePath).toBe(blackberry.io.sharedFolder + "/pictures/001.jpg");
             expect(photo.pref).toBe(true);
         });
 
@@ -309,7 +309,7 @@ describe("blackberry.pim.contacts", function () {
                     name: "Research In Motion"
                 },
                 workEmail = {
-                    type: ContactField.WORK, 
+                    type: ContactField.WORK,
                     value: "jfk@rim.com"
                 },
                 homeEmail = {
@@ -445,8 +445,8 @@ describe("blackberry.pim.contacts", function () {
                                               {"name": "IBM", "title": "Manager"},
                                               {"name": "The Cool Co.", "department": "Cooler", "title": "Mr. Cool"} ];
 
-                new_contact.photos = [ {originalFilePath: "/accounts/1000/shared/camera/earth.gif", pref: false},
-                                       {originalFilePath: "/accounts/1000/shared/camera/twitter.jpg", pref: true} ];
+                new_contact.photos = [ {originalFilePath: blackberry.io.sharedFolder + "/camera/earth.gif", pref: false},
+                                       {originalFilePath: blackberry.io.sharedFolder + "/camera/twitter.jpg", pref: true} ];
 
                 new_contact.note = "This is a test contact for the PIM WebWorks API";
                 new_contact.videoChat = ["abc", "def"];
@@ -1101,7 +1101,7 @@ describe("blackberry.pim.contacts", function () {
                     }, {
                         fieldName: ContactFindOptions.SEARCH_FIELD_GIVEN_NAME,
                         fieldValue: "Alessandro"
-                    }], 
+                    }],
                     sort: [{
                         fieldName: 23423,
                         desc: false
@@ -1144,7 +1144,7 @@ describe("blackberry.pim.contacts", function () {
                     }, {
                         fieldName: ContactFindOptions.SEARCH_FIELD_GIVEN_NAME,
                         fieldValue: "Alessandro"
-                    }], 
+                    }],
                     sort: [{
                         fieldName: ContactFindOptions.SORT_FIELD_FAMILY_NAME
                     }]
@@ -1329,7 +1329,7 @@ describe("blackberry.pim.contacts", function () {
                     }, {
                         "fieldName": ContactFindOptions.SEARCH_FIELD_FAMILY_NAME,
                         "fieldValue": "S"
-                    }], 
+                    }],
                     sort: [{
                         "fieldName": ContactFindOptions.SORT_FIELD_FAMILY_NAME,
                         "desc": false
@@ -1388,7 +1388,7 @@ describe("blackberry.pim.contacts", function () {
                     }, {
                         "fieldName": ContactFindOptions.SEARCH_FIELD_FAMILY_NAME,
                         "fieldValue": "S"
-                    }], 
+                    }],
                     sort: [{
                         "fieldName": ContactFindOptions.SORT_FIELD_FAMILY_NAME,
                         "desc": false

--- a/test/functional/automatic/crossOrigin.js
+++ b/test/functional/automatic/crossOrigin.js
@@ -749,11 +749,11 @@ describe("White listing", function () {
         // if declared <access uri="file:///store/home/user"></access>,
         // then access to files in /store/home should be disallowed.
         it("can access whitelisted file:// path", function () {
-            writeTestFile("/accounts/1000/shared/documents/textData.txt");
+            writeTestFile(blackberry.io.sharedFolder + "/documents/textData.txt");
 
             runs(function () {
                 console.log(blackberry.io.sharedFolder + '/documents/textData.txt');
-                testHtmlElementLoads('iframe', {src: 'file:///accounts/1000/shared/documents/textData.txt' });
+                testHtmlElementLoads('iframe', {src: 'file://' + blackberry.io.sharedFolder + '/documents/textData.txt' });
             });
         });
 
@@ -768,11 +768,11 @@ describe("White listing", function () {
         // <access uri='"/store/home/user/documents">
         // Validate that access to files in /store/home/user/documents/html is allowed.
         it("can access whitelisted file:// subdirectory", function () {
-            createTestDirectory("/accounts/1000/shared/documents/subdir");
-            writeTestFile("/accounts/1000/shared/documents/subdir/textData.txt");
+            createTestDirectory(blackberry.io.sharedFolder + "/documents/subdir");
+            writeTestFile(blackberry.io.sharedFolder + "/documents/subdir/textData.txt");
 
             runs(function () {
-                testHtmlElementLoads('iframe', {src: 'file:///accounts/1000/shared/documents/subdir/textData.txt' });
+                testHtmlElementLoads('iframe', {src: 'file://' + blackberry.io.sharedFolder + '/documents/subdir/textData.txt' });
             });
         });
 

--- a/test/functional/automation/blackberry.invoke.card.ics.js
+++ b/test/functional/automation/blackberry.invoke.card.ics.js
@@ -21,7 +21,7 @@ describe("blackberry.invoke.card.ics", function () {
     var waitTimeout = 2000;
 
     function pushIcsFileToDevice(callback) {
-        var dir = "/accounts/1000/shared/documents/",
+        var dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "test.ics",
             bb = new window.WebKitBlobBuilder();
 
@@ -105,7 +105,7 @@ describe("blackberry.invoke.card.ics", function () {
                 return flag;
             }, waitTimeout);
             runs(function () {
-                blackberry.invoke.card.invokeIcsViewer({uri: "file:///accounts/1000/shared/documents/test.ics"}, onDone, onCancel);
+                blackberry.invoke.card.invokeIcsViewer({uri: "file://" + blackberry.io.sharedFolder + "/documents/test.ics"}, onDone, onCancel);
                 waits(waitTimeout);
                 runs(function () {
                     internal.automation.touchBottomCenter();

--- a/test/functional/manual/blackberry.ui.cover.js
+++ b/test/functional/manual/blackberry.ui.cover.js
@@ -44,7 +44,7 @@ describe("blackberry.ui.cover", function () {
 
         it("sets window cover from file:///filepath", function () {
             var confirm,
-                path = "file:///accounts/1000/shared/downloads/windowcover.png",
+                path = "file://" + blackberry.io.sharedFolder + "/downloads/windowcover.png",
                 label = {"label": "Test 1", "size": 8},
                 blob,
                 flag = false,
@@ -70,7 +70,7 @@ describe("blackberry.ui.cover", function () {
                 xhr.onload = function (e) {
                     if (this.status === 200) {
                         blob = new window.Blob([this.response], {type:  'image/png'});
-                        writeBlobToPath(blob, 1024 * 1024, "/accounts/1000/shared/downloads/windowcover.png", function () {
+                        writeBlobToPath(blob, 1024 * 1024, blackberry.io.sharedFolder + "/downloads/windowcover.png", function () {
                             flag = true;
                         });
                     }

--- a/test/test-app/config.xml
+++ b/test/test-app/config.xml
@@ -114,11 +114,7 @@
         <feature id="blackberry.app" />
     </access>
 
-
-
-
-    <access uri="file:///accounts/1000/shared/documents/textData.txt" />
-    <access uri="file:///accounts/1000/shared/documents/subdir/textData.txt" />
+    <access uri="file:///accounts/1000/appData" />
 
     <license href="http://www.apache.org/licenses/LICENSE-2.0">
         Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test-suite/Apps/WildcardDomain/spec/crossOriginWildcard.js
+++ b/test/test-suite/Apps/WildcardDomain/spec/crossOriginWildcard.js
@@ -40,7 +40,7 @@ describe("Cross Origin Wildcard", function () {
                 console.log(e);
             }),
             fileWritten = false,
-            dir = "/accounts/1000/shared/documents/",
+            dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "textData.txt",
             bb = new window.WebKitBlobBuilder();
 
@@ -74,7 +74,7 @@ describe("Cross Origin Wildcard", function () {
             expect(errorHandler).wasNotCalled();
             expect(fileWritten).toBe(true);
 
-            testHtmlElementLoads('iframe', {src: 'file:///accounts/1000/shared/documents/textData.txt' });
+            testHtmlElementLoads('iframe', {src: 'file://' + blackberry.io.sharedFolder + '/documents/textData.txt' });
         });
     }
 
@@ -95,7 +95,7 @@ describe("Cross Origin Wildcard", function () {
             writeTestFile();
 
             runs(function () {
-                testHtmlElementLoads('iframe', { src : 'file:///accounts/1000/shared/documents/textData.txt' });
+                testHtmlElementLoads('iframe', { src : 'file://' + blackberry.io.sharedFolder + '/documents/textData.txt' });
                 sendReport(true);
             });
         });


### PR DESCRIPTION
Changes the testapp to not hardcode the sharedFolder, but to use
    blackberry.io.sharedFolder.

```
Reviewed By: Nukul Bhasin <nbhasin@rim.com>
Tested By: Tracy Li <tli@rim.com>
```
