### PR TITLE
Automates manual invoke test suite

### DIFF
--- a/ext-internal/automation/client.js
+++ b/ext-internal/automation/client.js
@@ -26,7 +26,7 @@ _self.SWIPE_DURATION = "500";
 // Return approximate width of footer's icon depend of what device orientation is
 _self.getFooterMenuIconWidth = function () {
     return screen.availWidth < screen.availHeight? 150 : 250;
-}
+};
 
 _self.swipeDown = function () {
     internal.pps.syncWrite(
@@ -139,7 +139,23 @@ _self.touchContextMenuShare = function () {
 _self.touchInvocationListItem = function (index) {
     _self.touch(screen.availWidth / 2 ,  (_self.INVOCATIONLIST_TITLE_HEIGHT - 25) + _self.INVOCATIONLIST_ITEM_HEIGHT * index);
     // touch past the cancel bar, plus each item width, with a 5 offset to actually touch the item
-}
+};
+
+_self.getForegroundAppInfo = function () {
+    var appInfo = {};
+    internal.pps.syncWrite(
+        {
+            _src: "desktop",
+            _dest: "navigator",
+            msg: "getForegroundAppInfo"
+        },
+        "/pps/services/automation/navigator/control"
+    );
+    internal.pps.syncRead("/pps/services/automation/navigator/output").output.response.slice(0, -1).split(";").forEach(function (element) {
+        appInfo[element.split("=")[0]] = element.split("=")[1];
+    });
+    return appInfo;
+};
 
 _self.injectText = function (inputText) {
     internal.pps.syncWrite(
@@ -158,6 +174,10 @@ _self.touchTopLeft = function () {
 
 _self.touchTopRight = function () {
     _self.touch(screen.availWidth - _self.TOUCH_SPACE_FROM_EDGE, _self.TOUCH_SPACE_FROM_EDGE);
+};
+
+_self.touchTopRightAppTile = function () {
+    _self.touch(screen.availWidth - 100, 300);
 };
 
 _self.showKeyboard = function () {

--- a/test/functional/automation/blackberry.invoke.js
+++ b/test/functional/automation/blackberry.invoke.js
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("blackberry.invoke", function () {
+    var onSuccess,
+        onError,
+        onSuccessFlag,
+        onErrorFlag,
+        invokeWait = 3000,
+        invokeCardWait = invokeWait * 3,
+        uiGestureWait = 750;
+
+    beforeEach(function () {
+        spyOn(window.webworks.event, 'isOn').andReturn(false);
+        onSuccessFlag = false;
+        onErrorFlag = false;
+        onSuccess = jasmine.createSpy("success callback").andCallFake(
+            function () {
+                onSuccessFlag = true;
+            });
+        onError = jasmine.createSpy("error callback").andCallFake(
+            function () {
+                onErrorFlag = true;
+            });
+    });
+
+    afterEach(function () {
+        onSuccess = null;
+        onError = null;
+        onSuccessFlag = false;
+        onErrorFlag = false;
+    });
+
+    it('invoke should invoke google.com with unbound invocation', function () {
+        var request = {
+            uri: "http://www.google.com"
+        };
+
+        try {
+            blackberry.invoke.invoke(request, onSuccess, onError);
+        } catch (e) {
+            console.log(e);
+        }
+        waits(invokeWait);
+        runs(function () {
+            expect(internal.automation.getForegroundAppInfo().label).toEqual("Browser");
+            internal.automation.swipeUp();
+            waits(uiGestureWait);
+            runs(function () {
+                internal.automation.touchTopRightAppTile();
+                waits(uiGestureWait);
+                runs(function () {
+                    expect(internal.automation.getForegroundAppInfo().label).toEqual("WebWorks Test App-en");
+                    expect(onSuccess).toHaveBeenCalled();
+                    expect(onError).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+
+    it('invoke should invoke google.com with bound invocation', function () {
+        var request = {
+            target: "sys.browser",
+            uri: "http://www.google.com"
+        };
+
+        try {
+            blackberry.invoke.invoke(request, onSuccess, onError);
+        } catch (e) {
+            console.log(e);
+        }
+        waits(invokeWait);
+        runs(function () {
+            expect(internal.automation.getForegroundAppInfo().label).toEqual("Browser");
+            internal.automation.swipeUp();
+            waits(uiGestureWait);
+            runs(function () {
+                internal.automation.touchTopRightAppTile();
+                waits(uiGestureWait);
+                runs(function () {
+                    expect(internal.automation.getForegroundAppInfo().label).toEqual("WebWorks Test App-en");
+                    expect(onSuccess).toHaveBeenCalled();
+                    expect(onError).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+
+    describe("Cards", function () {
+        var request = {
+            target: "com.webworks.test.functional.invoke.card.target",
+        },
+        onChildCardClosed,
+        onChildCardStartPeek,
+        onChildCardEndPeek;
+
+        beforeEach(function () {
+            onChildCardClosed = jasmine.createSpy("onChildCardClosed event");
+            onChildCardStartPeek = jasmine.createSpy("onChildCardStartPeek event");
+            onChildCardEndPeek = jasmine.createSpy("onChildCardEndPeek event");
+            blackberry.event.addEventListener("onChildCardClosed", onChildCardClosed);
+            blackberry.event.addEventListener("onChildCardStartPeek", onChildCardStartPeek);
+            blackberry.event.addEventListener("onChildCardEndPeek", onChildCardEndPeek);
+        });
+
+        afterEach(function () {
+            onChildCardClosed = null;
+            onChildCardStartPeek = null;
+            onChildCardEndPeek = null;
+            blackberry.event.removeEventListener("onChildCardClosed", onChildCardClosed);
+            blackberry.event.removeEventListener("onChildCardStartPeek", onChildCardStartPeek);
+            blackberry.event.removeEventListener("onChildCardEndPeek", onChildCardEndPeek);
+        });
+
+        it('invoke should invoke card, and close it with closeChildCard', function () {
+            try {
+                blackberry.invoke.invoke(request, onSuccess, onError);
+            } catch (e) {
+                console.log(e);
+            }
+            waits(invokeCardWait);
+            runs(function () {
+                expect(internal.automation.getForegroundAppInfo()["total-cards"]).toEqual("1");
+                expect(internal.automation.getForegroundAppInfo()["label-card0"]).toEqual("WebWorks Test App-en");
+                blackberry.invoke.closeChildCard();
+                waitsFor(function () {
+                    return onChildCardClosed.callCount;
+                });
+                runs(function () {
+                    expect(onSuccess).toHaveBeenCalled();
+                    expect(onError).not.toHaveBeenCalled();
+                    expect(internal.automation.getForegroundAppInfo()["total-cards"]).toEqual("0");
+                });
+            });
+        });
+
+        it('invoke should not invoke card whith invalid target name', function () {
+            request.target = "com.webworks.test.functional.invoke.card.invalid.target";
+            try {
+                blackberry.invoke.invoke(request, onSuccess, onError);
+            } catch (e) {
+                console.log(e);
+            }
+            waits(500);
+            runs(function () {
+                expect(internal.automation.getForegroundAppInfo()["total-cards"]).toEqual("0");
+                expect(onSuccess).not.toHaveBeenCalled();
+                expect(onError).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/test/test-app/automation/SpecRunner.htm
+++ b/test/test-app/automation/SpecRunner.htm
@@ -110,6 +110,7 @@
 
     <form id="featureList">
         <input type="checkbox" value="blackberry.app">blackberry.app</input><br />
+        <input type="checkbox" value="blackberry.invoke">blackberry.invoke</input><br />
         <input type="checkbox" value="blackberry.invoke.card.calendar">blackberry.invoke.card.calendar</input><br />
         <input type="checkbox" value="blackberry.invoke.card.camera">blackberry.invoke.card.camera</input><br />
         <input type="checkbox" value="blackberry.invoke.card.emailComposer">blackberry.invoke.card.emailComposer</input><br />

--- a/test/test-app/config.xml
+++ b/test/test-app/config.xml
@@ -137,6 +137,14 @@
         </filter>
     </rim:invoke-target>
 
+    <rim:invoke-target id="com.webworks.test.functional.invoke.card.target">
+        <type>card.previewer</type>
+        <filter>
+            <action>bb.action.WWTEST</action>
+            <mime-type>text/plain</mime-type>
+        </filter>
+    </rim:invoke-target>
+
     <rim:invoke-target id="com.webworks.test.functional.push.target">
         <type>APPLICATION</type>
         <filter>

--- a/test/test-app/manual/framework-split/main.htm
+++ b/test/test-app/manual/framework-split/main.htm
@@ -32,7 +32,7 @@
         </script>
 	</head>
 	<body>
-        <input id="backButton" type="button" value="Back" onclick="document.location.href = 'local:///index.htm';" />
+        <input id="backButton" type="button" value="Back" onclick="document.location.href = 'local:///index.html';" />
 
         <p> This WebWorks Smoke Test includes the following tests: </p>
         <p><input type="button" value="Camera Card" onclick="return do_camera_Test()" /></p>


### PR DESCRIPTION
Includes new automation function that allows the application to query the navigator for information about the current foreground application. 

This allows us to automate our invoke tests that require the tester to manually confirm the status of an invocation, for example: bound/unbound invocations, invoking the test app as a card etc..
