### PR TITLE
Fixes two minor bugs in connection where invalid results were given.

### DIFF
--- a/ext/connection/index.js
+++ b/ext/connection/index.js
@@ -40,6 +40,7 @@ function mapConnectionType(type, technology) {
     case 'cellular':
         switch (technology) {
         case 'edge':
+        case 'gsm':
             return '2g';
         case 'evdo':
             return '3g';
@@ -49,7 +50,7 @@ function mapConnectionType(type, technology) {
             return '4g';
         }
     }
-    return '';
+    return 'unknown';
 }
 
 function currentConnectionType() {


### PR DESCRIPTION
Fixes #429 and PR271932

```
Modifies the connection to no longer return empty string and to
return '2g' for 'gsm'
```
