### PR TITLE
Fixed calendar test failures

### DIFF
--- a/ext/pim.calendar/native/pim_calendar_qt.hpp
+++ b/ext/pim.calendar/native/pim_calendar_qt.hpp
@@ -84,7 +84,6 @@ private:
     static QList<QDateTime> setEventFields(bbpim::CalendarEvent& ev, const Json::Value& args, Json::Value& returnObj);
     static bbpim::CalendarService* getCalendarService();
     Json::Value populateEvent(const bbpim::CalendarEvent& event, bool isFind);
-    static unsigned int getEventHash(const bbpim::CalendarEvent& event);
     static std::string eventToString(const bbpim::CalendarEvent& event);
     static Json::Value eventToJson(const bbpim::CalendarEvent& event);
 

--- a/test/functional/automatic/blackberry.pim.calendar.js
+++ b/test/functional/automatic/blackberry.pim.calendar.js
@@ -1113,13 +1113,13 @@ describe("blackberry.pim.calendar", function () {
 
         it('Can save a monthly recurring event on device', function () {
             if (isDefaultFolderAccessible()) {
-                var start = new Date("Jan 6, 2013, 12:00"),
-                    end = new Date("Jan 6, 2013, 12:30"),
+                var start = new Date("Jan 6, 2046, 12:00"),
+                    end = new Date("Jan 6, 2046, 12:30"),
                     location = "some location",
                     summary = "WebWorksTest awesome recurring event (wwt006)",
                     rule = new CalendarRepeatRule({
                         "frequency": CalendarRepeatRule.FREQUENCY_MONTHLY,
-                        "expires": new Date("Dec 31, 2013"),
+                        "expires": new Date("Dec 31, 2046"),
                         "numberOfOccurrences": 4
                     }),
                     called = false,
@@ -1218,10 +1218,10 @@ describe("blackberry.pim.calendar", function () {
                             expect(evt.allDay).toBe(recEvent.allDay);
                         });
 
-                        expect(starts).toContain(new Date("Jan 6, 2013, 12:00").toISOString());
-                        expect(starts).toContain(new Date("Feb 6, 2013, 12:00").toISOString());
-                        expect(starts).toContain(new Date("Mar 6, 2013, 12:00").toISOString());
-                        expect(starts).toContain(new Date("Apr 6, 2013, 12:00").toISOString());
+                        expect(starts).toContain(new Date("Jan 6, 2046, 12:00").toISOString());
+                        expect(starts).toContain(new Date("Feb 6, 2046, 12:00").toISOString());
+                        expect(starts).toContain(new Date("Mar 6, 2046, 12:00").toISOString());
+                        expect(starts).toContain(new Date("Apr 6, 2046, 12:00").toISOString());
 
                         called = true;
                     }),

--- a/test/test-suite/Apps/Calendar/config.xml
+++ b/test/test-suite/Apps/Calendar/config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget xmlns=" http://www.w3.org/ns/widgets"
+        xmlns:rim="http://www.blackberry.com/ns/widgets"
+        version="1.0.0"
+        id="CalendarTest">
+
+    <name>Calendar Test</name>
+
+    <description>This application tests WebWorks calendar API.</description>
+
+    <content src="index.html"/>
+
+    <author rim:copyright="Copyright 1998-2011 My Corp" email="hello.bob@blah.com" href="http://www.blah.com">Research In Motion Ltd.</author>
+
+    <feature id="blackberry.app" required="true" version="1.0.0.0">
+        <param name="backgroundColor" value="0xFFEFD5" />
+    </feature>
+    <feature id="blackberry.pim.calendar" required="true" version="1.0.0.0" />
+
+    <license href="http://www.apache.org/licenses/LICENSE-2.0">
+        Licensed under the Apache License, Version 2.0 (the "License");
+        #you may not use this file except in compliance with the License.
+        #You may obtain a copy of the License at
+        #
+        #http://www.apache.org/licenses/LICENSE-2.0
+        #
+        #Unless required by applicable law or agreed to in writing, software
+        #distributed under the License is distributed on an "AS IS" BASIS,
+        #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        #See the License for the specific language governing permissions and limitations under the License.
+    </license>
+
+    <rim:permissions>
+        <rim:permit>access_pimdomain_calendars</rim:permit>
+    </rim:permissions>
+</widget>

--- a/test/test-suite/Apps/Calendar/index.html
+++ b/test/test-suite/Apps/Calendar/index.html
@@ -1,0 +1,185 @@
+<html>
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+	<link rel="stylesheet" href="textarea.css" type="text/css" media="screen" />
+	<script type="text/javascript" src="local:///chrome/webworks.js"></script>
+	<script type="text/javascript" src="textarea.js"></script>
+	<script type="text/javascript">
+		var cal,
+			evt;
+
+		function init() {
+			cal = blackberry.pim.calendar;
+		}
+
+	    window.addEventListener("load", function(e) {
+	        document.addEventListener("webworksready", function(e) {
+	           init();
+	        }, false);
+	    }, false);
+
+		function getDefaultFolder() {
+			textarea.clear();
+			try {
+				var folder = cal.getDefaultCalendarFolder();
+
+				textarea.append("Default folder details:");
+				textarea.append("ID: " + folder.id);
+				textarea.append("Name: " + folder.name);
+				textarea.append("Owner Email: " + folder.ownerEmail);
+				textarea.append("Default: " + folder.default);
+				textarea.append("Enterprise: " + folder.enterprise);
+			} catch (e) {
+				textarea.append("Error: " + e.message);
+			}
+		}
+
+		function createAndSave() {
+			textarea.clear();
+			try {
+				evt = cal.createEvent({
+					"start": new Date("Jan 1, 2013, 12:00"),
+					"end": new Date("Jan 1, 2013, 14:00"),
+					"summary": document.getElementById("summary").value,
+					"location": "Secret"
+				});
+				evt.save(function (saved) {
+						evt = saved;
+						textarea.append("Event saved successfully");
+						textarea.append("Start: " + evt.start);
+						textarea.append("End: " + evt.end);
+						textarea.append("Summary: " + evt.summary);
+						textarea.append("Location: " + evt.location);
+					}, function (error) {
+						textarea.append("Failed to save, error: " + error.code);
+					});
+			} catch (e) {
+				textarea.append("Error: " + e.message);
+			}
+		}
+
+		function editAndSave() {
+			textarea.clear();
+			if (evt) {
+				try {
+					evt.location = "Edited";
+					evt.save(function (saved) {
+							evt = saved;
+							textarea.append("Event (edited) saved successfully");
+							textarea.append("Start: " + evt.start);
+							textarea.append("End: " + evt.end);
+							textarea.append("Summary: " + evt.summary);
+							textarea.append("Location: " + evt.location);
+						}, function (error) {
+							textarea.append("Failed to save, error: " + error.code);
+						});
+				} catch (e) {
+					textarea.append("Error: " + e.message);
+				}
+			}
+		}
+
+		function findEvents() {
+			textarea.clear();
+			try {
+				var findOptions = {
+					"filter": {
+						"substring": document.getElementById("summary").value
+					},
+					"detail": cal.CalendarFindOptions.DETAIL_AGENDA,
+					"expandRecurring": false
+				};
+				cal.findEvents(findOptions,
+					function (events) {
+						textarea.append("# events found: " + events.length);
+						events.forEach(function (e, i) {
+							textarea.append("Event " + i + ":");
+							textarea.append("Start: " + e.start);
+							textarea.append("End: " + e.end);
+							textarea.append("Summary: " + e.summary);
+							textarea.append("Location: " + e.location);
+						});
+					}, function (error) {
+						textarea.append("Failed to find, error: " + error.code);
+						textarea.append(error.code);
+					});
+			} catch (e) {
+				textarea.append("Error: " + e.message);
+			}
+		}
+
+		function removeEvent() {
+			textarea.clear();
+			try {
+				evt.remove(function () {
+					textarea.append("Event removed successfully");
+				}, function (error) {
+					textarea.append("Error removed event: " + error.code);
+				});
+			} catch (e) {
+				textarea.append("Error: " + e.message);
+			}
+		}
+
+		function createRecurringEvent() {
+			textarea.clear();
+			var start = new Date("Jan 6, 2014, 12:00"),
+                end = new Date("Jan 6, 2014, 12:30"),
+                venue = "some location",
+                summary = document.getElementById("summary").value,
+                rule = {
+                    "frequency": cal.CalendarRepeatRule.FREQUENCY_MONTHLY,
+                    "expires": new Date("Dec 31, 2014"),
+                    "numberOfOccurrences": 4
+                };
+			var recEvent = cal.createEvent({
+				"start": start,
+				"end": end,
+				"location": venue,
+				"summary": summary,
+				"recurrence": rule
+			});
+			recEvent.save(function (saved) {
+				textarea.append("Recurring event created!");
+				textarea.append(saved);
+			}, function (error) {
+				textarea.append("Failed to save recurring event");
+			});
+		}
+
+		function removeSingleOccurrence() {
+			textarea.clear();
+			cal.findEvents({
+				"filter": {
+					"substring": document.getElementById("summary").value,
+					"expandRecurring": true
+				}
+			}, function (events) {
+				textarea.append("Found " + events.length + " occurrences!");
+
+				if (events.length > 0) {
+					events[events.length - 1].remove(function () {
+						textarea.append("Removed! Now check if it's just the last occurrence is gone");
+					}, function () {
+						textarea.append("Failed to remove");
+					},
+					false);
+				}
+			}, function (error) {
+				textarea.append("Failed to find!");
+			});
+		}
+	</script>
+</head>
+<body class="dark" onload="textarea.init()">
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="getDefaultFolder()" value="Default Folder"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="createAndSave()" value="Create Event"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="editAndSave()" value="Edit Event"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="findEvents()" value="Find"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="removeEvent()" value="Remove"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" id="summary" type="text" size="10"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="createRecurringEvent()" value="Create Recurring Event"><br><br>
+	<input style="width: 100px; height: 100px; font-size: 200%" type="button" onclick="removeSingleOccurrence()" value="Remove Single Occurrence">
+	<textarea></textarea>
+</body>
+</html>

--- a/test/test-suite/Apps/Calendar/textarea.css
+++ b/test/test-suite/Apps/Calendar/textarea.css
@@ -1,0 +1,30 @@
+body.dark   { background-color: #000 }
+body.light  { background-color: #eee }
+
+textarea {
+  position: absolute;
+  top: 5%;
+  left: 25%;
+  right: 25%;
+  bottom: 5%;
+  width: 50%;
+  height: 90%;
+  border-style: solid;
+  border-width: 1px;
+  font-family: Pragmata, Consolas, Monaco, "Andale Mono", "Bitstream Vera Sans Mono", monospace;
+  font-size: 12px;
+  text-align: left;
+  resize: none;
+}
+
+body.dark textarea {
+  border-color: #111;
+  background-color: #222;
+  color: #0f0;
+}
+
+body.light textarea {
+  border-color: #ddd;
+  background-color: #fff;
+  color: #333;
+}

--- a/test/test-suite/Apps/Calendar/textarea.js
+++ b/test/test-suite/Apps/Calendar/textarea.js
@@ -1,0 +1,20 @@
+textarea = {
+  textarea: null,
+  init: function() {
+    this.textarea = document.getElementsByTagName('textarea')[0];
+    this.textarea.focus();
+    this.load();
+  },
+  load: function() {
+    //this.textarea.value = localStorage.getItem('text');
+  },
+  save: function() {
+    //localStorage.setItem('text', this.textarea.value)
+  },
+  clear: function() {
+    this.textarea.value = "";
+  },
+  append: function(str) {
+    this.textarea.value += str + "\n";
+  }
+}


### PR DESCRIPTION
Removed the synchronization check and do not populate unnecessary fields

Also added a test app for basic manual tests.

@dylin The extra properties that you populate for the synchronization check caused some serious issues, the Calendar app is completely busted. I took out the hash and the synchronization check.

@pagey Can you do a code review please?
