### PR TITLE
modifies setup instructions ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WebWorks is an application framework and packaging tool that allows a developer 
 This repo contains the code for the BlackBerry 10 WebWorks Framework.
 
 ##Prerequisites
-1. Install [node[v0.6.10] and npm](http://nodejs.org/dist/v0.6.10/) and add to path.
+1. Install [node and npm](http://nodejs.org/download/) and add to path.
 2. Install [BlackBerry Native SDK](https://bdsc.webapps.blackberry.com/native/).
 3. [*Windows*] Add Git bin to PATH. i.e. `*Installation Directory*\bin`
 

--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ else
     sudo npm install -g jake jshint@0.5.2 uglify-js
 fi
 
-npm install jasmine-node express wrench@1.3.6 jWorkflow mustache node-native-zip
+npm install jasmine-node express wrench jWorkflow mustache node-native-zip
 
 #Don't grab submodules for SCM builds (already included in productization repo)
 if [ "$1" != "-scm" ]; then


### PR DESCRIPTION
... to remove references to specific versions of node and the wrench module
based on recent experience setting up 64-bit Windows 7 for the first time.

issues documented here https://github.com/blackberry/BB10-WebWorks-Framework/issues/523
