### PR TITLE
Kill deploy-automation 20 seconds after starting agents.

### DIFF
--- a/build/deploy-automation.js
+++ b/build/deploy-automation.js
@@ -67,8 +67,12 @@ function onError(stderr) {
 }
 
 function execAgent(ip) {
+    var child;
     console.log('Starting automation agents...');
-    childProcess.spawn('ssh', getRunAgentCmd(ip), [], { stdio: 'inherit', detached: true });
+    child = childProcess.spawn('ssh', getRunAgentCmd(ip), [], { stdio: 'ignore', detached: true });
+    setTimeout(function () {
+        child.kill();
+    }, 20000);
 }
 
 function execCopy(ip, user) {


### PR DESCRIPTION
Issue #529

Removes the nuisance of having to kill the script manually
