### PR TITLE
Clear selection after context menu test and increase the long press time

### DIFF
--- a/ext-internal/automation/client.js
+++ b/ext-internal/automation/client.js
@@ -86,7 +86,7 @@ _self.longTouch = function (x, y) {
             points : "[[(" + x + "," + y + ")]]",
             _src: "desktop",
             _dest: "ui-agent",
-            duration: 1000
+            duration: 1500
         },
         "/pps/services/agent/ui-agent/control"
     );
@@ -126,10 +126,6 @@ _self.touchTopRight = function () {
 
 _self.touchCenter = function () {
     _self.touch(screen.availWidth / 2, screen.availHeight / 2);
-};
-
-_self.triggerContextMenu = function (x, y) {
-    _self.longTouch(x, y);
 };
 
 _self.touchContextMenuShare = function () {

--- a/test/functional/automation/blackberry.ui.contextmenu.js
+++ b/test/functional/automation/blackberry.ui.contextmenu.js
@@ -20,6 +20,12 @@ describe("blackberry.ui.contextmenu", function () {
 
     describe("Can invoke the Context Menu", function () {
 
+        afterEach(function () {
+            internal.automation.touchCenter();
+            waits(waitTimeout);
+            runs(function () { });
+        });
+
         it("should display a Context Menu and invoke a share targets screen", function () {
             var callback = jasmine.createSpy().andCallFake(function (request) {
                     return null; //Cancels invocation
@@ -28,8 +34,8 @@ describe("blackberry.ui.contextmenu", function () {
             // trigger a Context Menu
             waits(waitTimeout);
             runs(function () {
-                internal.automation.triggerContextMenu(120, 50);
-                internal.automation.triggerContextMenu(120, 50);
+                internal.automation.longTouch(120, 50);
+                internal.automation.longTouch(120, 50);
             });
 
             blackberry.invoke.interrupter = callback;


### PR DESCRIPTION
Issue #548

This prevents context menu test from interfering with other automation specs.
