### PR TITLE
Added additional "escape" layer for event "args"

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -22,7 +22,7 @@ module.exports = {
         //Change arguments into a real array instead of a fake one
         var args = Array.prototype.slice.call(arguments);
         //Send all the arguments as JSON
-        _webview.executeJavascript("webworks.event.trigger('" + name + "', '" + encodeURIComponent(JSON.stringify(args.slice(1))) + "')");
+        _webview.executeJavascript("webworks.event.trigger('" + name + "', '" + escape(encodeURIComponent(JSON.stringify(args.slice(1)))) + "')");
     },
 
     add: function (action) {

--- a/lib/public/event.js
+++ b/lib/public/event.js
@@ -71,7 +71,7 @@ module.exports = {
         var parsedArgs;
         if (_handlers.hasOwnProperty(name)) {
             if (args && args !== "undefined") {
-                parsedArgs = JSON.parse(decodeURIComponent(args));
+                parsedArgs = JSON.parse(decodeURIComponent(unescape(args)));
             }
             //Call the handlers
             _handlers[name].forEach(function (handler) {

--- a/test/unit/lib/event.js
+++ b/test/unit/lib/event.js
@@ -24,19 +24,19 @@ describe("event", function () {
         it("can invoke the webview execute javascript", function () {
             spyOn(webview, "executeJavascript");
             event.trigger("foo", {"id": 123});
-            expect(webview.executeJavascript).toHaveBeenCalledWith("webworks.event.trigger('foo', '" + encodeURIComponent(JSON.stringify([{"id": 123}])) + "')");
+            expect(webview.executeJavascript).toHaveBeenCalledWith("webworks.event.trigger('foo', '" + escape(encodeURIComponent(JSON.stringify([{"id": 123}]))) + "')");
         });
 
         it("can invoke the webview execute javascript", function () {
             spyOn(webview, "executeJavascript");
             event.trigger("foo");
-            expect(webview.executeJavascript).toHaveBeenCalledWith("webworks.event.trigger('foo', '" + encodeURIComponent(JSON.stringify([])) + "')");
+            expect(webview.executeJavascript).toHaveBeenCalledWith("webworks.event.trigger('foo', '" + escape(encodeURIComponent(JSON.stringify([]))) + "')");
         });
 
         it("sends multiple arguments passed in across as a JSONified array", function () {
             spyOn(webview, "executeJavascript");
             event.trigger("foo", {"id": 123, "foo": "hello world", list: [1, 2, 3]}, "Grrrrrrr", "Arrrrg");
-            expect(webview.executeJavascript).toHaveBeenCalledWith("webworks.event.trigger('foo', '" + encodeURIComponent(JSON.stringify([{"id": 123, foo: "hello world", list: [1, 2, 3]}, "Grrrrrrr", 'Arrrrg'])) + "')");
+            expect(webview.executeJavascript).toHaveBeenCalledWith("webworks.event.trigger('foo', '" + escape(encodeURIComponent(JSON.stringify([{"id": 123, foo: "hello world", list: [1, 2, 3]}, "Grrrrrrr", 'Arrrrg']))) + "')");
         });
     });
 


### PR DESCRIPTION
in order to work with "'" in the String,
as encodeURIComponent does not escape "'".
Also updated unit test.

Fixed https://github.com/blackberry/BB10-WebWorks-Framework/issues/385

Reviewed by @erikj54
Tested by @ericleili @DanielAudino @tracyli
