### PR TITLE
Update app.lockOrientation to pass recieveRotateEvents to webplatform

### DIFF
--- a/ext/app/client.js
+++ b/ext/app/client.js
@@ -106,7 +106,7 @@ defineReadOnlyField("licenseURL");
 defineReadOnlyField("version");
 
 function lockOrientation(orientation, receiveRotateEvents) {
-    return window.webworks.execSync(ID, "lockOrientation", { orientation: orientation });
+    return window.webworks.execSync(ID, "lockOrientation", { orientation: orientation, receiveRotateEvents: receiveRotateEvents });
 }
 
 function unlockOrientation() {

--- a/ext/app/index.js
+++ b/ext/app/index.js
@@ -194,11 +194,12 @@ module.exports = {
 
     lockOrientation : function (success, fail, args, env) {
         var orientation = JSON.parse(decodeURIComponent(args.orientation)),
-            rotateTo = translateToDeviceOrientation(orientation);
+            rotateTo = translateToDeviceOrientation(orientation),
+            recieveRotateEvents = args.recieveRotateEvents === undefined  ? true : args.recieveRotateEvents;
 
         // Force rotate to the given orientation then lock it
         qnx.webplatform.getApplication().rotate(rotateTo);
-        qnx.webplatform.getApplication().lockRotation(true);
+        qnx.webplatform.getApplication().lockRotation(recieveRotateEvents);
         success(true);
     },
 

--- a/test/unit/ext/app/client.js
+++ b/test/unit/ext/app/client.js
@@ -182,8 +182,8 @@ describe("app client", function () {
     describe("lockOrientation", function () {
         it("should call execSync", function () {
             mockedWebworks.execSync = jasmine.createSpy();
-            client.lockOrientation('portrait-primary');
-            expect(mockedWebworks.execSync).toHaveBeenCalledWith(_ID, "lockOrientation", { orientation: 'portrait-primary' });
+            client.lockOrientation('portrait-primary', false);
+            expect(mockedWebworks.execSync).toHaveBeenCalledWith(_ID, "lockOrientation", { orientation: 'portrait-primary', receiveRotateEvents: false });
         });
     });
 

--- a/test/unit/ext/app/index.js
+++ b/test/unit/ext/app/index.js
@@ -133,12 +133,24 @@ describe("app index", function () {
         it("calls webplatform rotate and lock methods", function () {
             var success = jasmine.createSpy(),
                 fail = jasmine.createSpy(),
-                mockArgs = { orientation : encodeURIComponent("\"landscape-primary\"") };
+                mockArgs = { orientation : encodeURIComponent("\"landscape-primary\""), recieveRotateEvents: undefined };
 
             index.lockOrientation(success, fail, mockArgs, null);
             expect(fail).not.toHaveBeenCalled();
             expect(success).toHaveBeenCalledWith(true);
             expect(mockedRotate).toHaveBeenCalledWith("left_up");
+            expect(mockedLockRotation).toHaveBeenCalledWith(true);
+        });
+        it("allows recieveRotateEvents to be set to false", function () {
+            var success = jasmine.createSpy(),
+                fail = jasmine.createSpy(),
+                mockArgs = { recieveRotateEvents: false, orientation : encodeURIComponent("\"landscape-primary\"") };
+
+            index.lockOrientation(success, fail, mockArgs, null);
+            expect(fail).not.toHaveBeenCalled();
+            expect(success).toHaveBeenCalledWith(true);
+            expect(mockedRotate).toHaveBeenCalledWith("left_up");
+            expect(mockedLockRotation).toHaveBeenCalledWith(false);
         });
     });
 


### PR DESCRIPTION
Issue #583

This is currently set to true by default, but it causes the bezel gestures to be tied to device rather than app. If the app isn't interested in rotation events while locked, this gives them a way to work around the problem.

I am following up with the navigator team separately to see if there is a bug on their end.
