### PR TITLE
Unregister events when window is unloading

### DIFF
--- a/ext/app/client.js
+++ b/ext/app/client.js
@@ -122,6 +122,10 @@ Object.defineProperty(_self, "lockOrientation", {"value": lockOrientation, "writ
 Object.defineProperty(_self, "unlockOrientation", {"value": unlockOrientation, "writable": false});
 Object.defineProperty(_self, "rotate", {"value": rotate, "writable": false});
 
-window.webworks.execSync(ID, "registerEvents", null);
+window.webworks.execSync(ID, "registerEvents");
+
+window.addEventListener("beforeunload", function () {
+    window.webworks.execSync(ID, "unregisterEvents");
+});
 
 module.exports = _self;

--- a/ext/app/index.js
+++ b/ext/app/index.js
@@ -176,6 +176,19 @@ module.exports = {
         }
     },
 
+    unregisterEvents: function (success, fail, args, env) {
+        try {
+            //HACK: These events are registered differently than
+            //      all the others so we need to remove them manually
+            _appEvents.removeEventListener("rotate", rotateTrigger);
+            _appEvents.removeEventListener("rotateWhenLocked", rotateWhenLockedTrigger);
+
+            success();
+        } catch (e) {
+            fail(-1, e);
+        }
+    },
+
     getReadOnlyFields : function (success, fail, args, env) {
         var ro = {
             author: _config.author,

--- a/ext/event/client.js
+++ b/ext/event/client.js
@@ -15,9 +15,11 @@
  */
 
 var _self = {}, 
-    _ID = require("./manifest.json").namespace;
+    _ID = require("./manifest.json").namespace,
+    events = [];
 
 _self.addEventListener = function (eventType, cb) {
+    events.push({type: eventType, func: cb});
     window.webworks.event.add(_ID, eventType, cb);
 };
 
@@ -25,5 +27,10 @@ _self.removeEventListener = function (eventType, cb) {
     window.webworks.event.remove(_ID, eventType, cb);
 };
 
+window.addEventListener("beforeunload", function () {
+    events.forEach(function (event) {
+        _self.removeEventListener(event.type, event.func);
+    });
+});
 
 module.exports = _self;

--- a/lib/event.js
+++ b/lib/event.js
@@ -39,6 +39,5 @@ module.exports = {
         } else {
             throw "Action is null or undefined";
         }
-
     }
 };

--- a/test/unit/ext/app/client.js
+++ b/test/unit/ext/app/client.js
@@ -17,6 +17,7 @@ var _extDir = __dirname + "./../../../../ext",
     _apiDir = _extDir + "/app",
     _ID = require(_apiDir + "/manifest").namespace,
     client,
+    cleanup,
     mockData = {
         author: "testAuthor",
         authorEmail: "testEmail",
@@ -50,6 +51,12 @@ describe("app client", function () {
         };
         GLOBAL.window = {
             webworks: mockedWebworks,
+            addEventListener: jasmine.createSpy().andCallFake(function (type, func) {
+                cleanup = {
+                    type: type,
+                    func: func
+                };
+            }),
             orientation: 0
         };
         GLOBAL.navigator = {
@@ -200,6 +207,17 @@ describe("app client", function () {
             mockedWebworks.execSync = jasmine.createSpy();
             client.rotate('landscape');
             expect(mockedWebworks.execSync).toHaveBeenCalledWith(_ID, "rotate", {orientation: 'landscape'});
+        });
+    });
+
+    describe("when cleaning up", function () {
+        it("added a listener to beforeunload", function () {
+            expect(cleanup).toEqual({type: "beforeunload", func: jasmine.any(Function)});
+        });
+
+        it("calls unregister events when the beforeunload calback is triggered", function () {
+            cleanup.func();
+            expect(window.webworks.execSync).toHaveBeenCalledWith(_ID, "unregisterEvents");
         });
     });
 });

--- a/test/unit/ext/app/index.js
+++ b/test/unit/ext/app/index.js
@@ -314,4 +314,37 @@ describe("app index", function () {
             testUnRegisterEvent("keyboardPosition");
         });
     });
+
+    describe("unregisterEvents", function () {
+        var appEvents = require(_libDir + "events/applicationEvents"),
+            success,
+            error;
+
+        beforeEach(function () {
+            spyOn(appEvents, "removeEventListener");
+            success = jasmine.createSpy("success");
+            error = jasmine.createSpy("error");
+        });
+
+        it("removes the rotate event", function () {
+            index.unregisterEvents(success);
+            expect(appEvents.removeEventListener).toHaveBeenCalledWith("rotate", jasmine.any(Function));
+        });
+
+        it("removes the rotateWhenLocked event", function () {
+            index.unregisterEvents(success);
+            expect(appEvents.removeEventListener).toHaveBeenCalledWith("rotateWhenLocked", jasmine.any(Function));
+        });
+
+        it("calls the success callback", function () {
+            index.unregisterEvents(success, error);
+            expect(success).toHaveBeenCalledWith();
+            expect(error).not.toHaveBeenCalled();
+        });
+
+        it("calls the error callback when there is an exception thrown", function () {
+            index.unregisterEvents(null, error);
+            expect(error).toHaveBeenCalledWith(-1, jasmine.any(Error));
+        });
+    });
 });

--- a/test/unit/ext/event/client.js
+++ b/test/unit/ext/event/client.js
@@ -27,11 +27,18 @@ var _apiDir = __dirname + "./../../../../ext/event/",
 
 describe("Event Listener", function () {
 
+    var cleanup;
+
     beforeEach(function () {
         //Set up mocking, no need to "spyOn" since spies are included in mock
         GLOBAL.window  = {
             webworks : mockedWebworks,
-            addEventListener: jasmine.createSpy()
+            addEventListener: jasmine.createSpy().andCallFake(function (type, func) {
+                cleanup = {
+                    type: type,
+                    func: func
+                };
+            })
         };
         client = require(_apiDir + "client");
     });
@@ -55,4 +62,14 @@ describe("Event Listener", function () {
         expect(mockedWebworks.event.remove).toHaveBeenCalledWith(_ID, eventType, JamesBond);
     });
 
+    it("added a listener to beforeunload", function () {
+        expect(cleanup).toEqual({type: "beforeunload", func: jasmine.any(Function)});
+    });
+
+    it("calls removeEventListener when the beforeunload callback is triggered", function () {
+        spyOn(client, "removeEventListener");
+        client.addEventListener("awesome", function () { });
+        cleanup.func();
+        expect(client.removeEventListener).toHaveBeenCalled();
+    });
 });

--- a/test/unit/ext/event/client.js
+++ b/test/unit/ext/event/client.js
@@ -29,7 +29,10 @@ describe("Event Listener", function () {
 
     beforeEach(function () {
         //Set up mocking, no need to "spyOn" since spies are included in mock
-        GLOBAL.window  = {webworks : mockedWebworks};
+        GLOBAL.window  = {
+            webworks : mockedWebworks,
+            addEventListener: jasmine.createSpy()
+        };
         client = require(_apiDir + "client");
     });
 


### PR DESCRIPTION
Fixes #546

```
Keep a list of events that are registered and on beforeunload
call removeEventListener for each of them.

There is no need to worry about if the user calls remove since
calling remove with an event and func that doesn't exist does
nothing, keeps the code simpler.  The same goes for worrying
about grouping / keeping track of duplicates since the extra
calls to remove does nothing.
```
