### PR TITLE
Replace WebKitBlobBuilder with Blob in blackberry.io test cases

### DIFF
--- a/test/functional/automatic/blackberry.io.js
+++ b/test/functional/automatic/blackberry.io.js
@@ -6,7 +6,7 @@ describe("FileSystem API", function () {
             }),
             fileWritten = false,
             fileName = "textData.txt",
-            bb = new window.WebKitBlobBuilder();
+            blob = new Blob(['this is text data'], {type: 'text/plain'});
 
         runs(function () {
 
@@ -14,8 +14,7 @@ describe("FileSystem API", function () {
                 fileWriter.onwriteend = function (e) {
                     fileWritten = true;
                 };
-                bb.append('this is text data');
-                fileWriter.write(bb.getBlob('text/plain'));
+                fileWriter.write(blob);
             }
 
             function gotFile(fileEntry) {
@@ -91,7 +90,7 @@ describe("FileSystem API", function () {
             fileWritten = false,
             dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "textData.txt",
-            bb = new window.WebKitBlobBuilder();
+            blob = new Blob(['this is text data'], {type: 'text/plain'});
 
         runs(function () {
             blackberry.io.sandbox = false;
@@ -100,8 +99,7 @@ describe("FileSystem API", function () {
                 fileWriter.onwriteend = function (e) {
                     fileWritten = true;
                 };
-                bb.append('this is text data');
-                fileWriter.write(bb.getBlob('text/plain'));
+                fileWriter.write(blob);
             }
 
             function gotFile(fileEntry) {

--- a/test/functional/automatic/crossOrigin.js
+++ b/test/functional/automatic/crossOrigin.js
@@ -361,7 +361,7 @@ describe("White listing", function () {
                 console.log('File write failure', JSON.stringify(e));
             }),
             fileWritten = false,
-            bb = new window.WebKitBlobBuilder();
+            blob = new Blob(['this is text data'], {type: 'text/plain'});
 
         runs(function () {
             blackberry.io.sandbox = false;
@@ -370,8 +370,7 @@ describe("White listing", function () {
                 fileWriter.onwriteend = function (e) {
                     fileWritten = true;
                 };
-                bb.append('this is text data');
-                fileWriter.write(bb.getBlob('text/plain'));
+                fileWriter.write(blob);
             }
 
             function gotFile(fileEntry) {

--- a/test/functional/automation/blackberry.invoke.card.ics.js
+++ b/test/functional/automation/blackberry.invoke.card.ics.js
@@ -23,7 +23,16 @@ describe("blackberry.invoke.card.ics", function () {
     function pushIcsFileToDevice(callback) {
         var dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "test.ics",
-            bb = new window.WebKitBlobBuilder();
+            blob = new Blob(["BEGIN:VCALENDAR\n",
+                             "PRODID:-//Research In Motion//RIM App//EN\n",
+                             "VERSION:1.0\n",
+                             "BEGIN:VEVENT\n",
+                             "DTEND:20210101T003000Z\n",
+                             "DTSTART:20210101T000000Z\n",
+                             "SUMMARY:invokeIcsViewer Test Event\n",
+                             "UID:" + generateUUID() + "\n",
+                             "END:VEVENT\n",
+                             "END:VCALENDAR\n"], {type: 'text/plain'});
 
         blackberry.io.sandbox = false;
 
@@ -45,18 +54,8 @@ describe("blackberry.invoke.card.ics", function () {
             fileWriter.onwriteend = function (e) {
                 callback();
             };
-            bb.append("BEGIN:VCALENDAR\n");
-            bb.append("PRODID:-//Research In Motion//RIM App//EN\n");
-            bb.append("VERSION:1.0\n");
-            bb.append("BEGIN:VEVENT\n");
-            bb.append("DTEND:20210101T003000Z\n");
-            bb.append("DTSTART:20210101T000000Z\n");
-            bb.append("SUMMARY:invokeIcsViewer Test Event\n");
-            bb.append("UID:" + generateUUID() + "\n");
-            bb.append("END:VEVENT\n");
-            bb.append("END:VCALENDAR\n");
 
-            fileWriter.write(bb.getBlob('text/plain'));
+            fileWriter.write(blob);
         }
 
         function errorHandler(e) {

--- a/test/test-suite/Apps/WildcardDomain/spec/crossOriginWildcard.js
+++ b/test/test-suite/Apps/WildcardDomain/spec/crossOriginWildcard.js
@@ -42,7 +42,7 @@ describe("Cross Origin Wildcard", function () {
             fileWritten = false,
             dir = blackberry.io.sharedFolder + "/documents/",
             fileName = "textData.txt",
-            bb = new window.WebKitBlobBuilder();
+            blob = new Blob(['this is text data'], {type: 'text/plain'});
 
         runs(function () {
             blackberry.io.sandbox = false;
@@ -51,8 +51,7 @@ describe("Cross Origin Wildcard", function () {
                 fileWriter.onwriteend = function (e) {
                     fileWritten = true;
                 };
-                bb.append('this is text data');
-                fileWriter.write(bb.getBlob('text/plain'));
+                fileWriter.write(blob);
             }
 
             function gotFile(fileEntry) {


### PR DESCRIPTION
Replace WebKitBlobBuilder with Blob as WebKitBlobBuilder is deprecated in trunk and 10.2

Reviewed by: @bryanhiggins 
Tested by: Kris Flores
